### PR TITLE
pip install -r requirements.txt – fails on fresh install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     ],
     keywords='faker fixtures data test django',
     long_description=read_file('README.rst'),
+    setup_requires=['django',],
     install_requires=['django','fake-factory>=0.2'],
     tests_require=['django','fake-factory>=0.2'],
     test_suite="runtests.runtests",


### PR DESCRIPTION
because pip hasn't installed django yet, which is referenced by the `django_faker/__init__.py`

adding setup_requires as an 'abstract' dependency in addition to install_requires, as according to the documentation:

"...projects listed in setup_requires will NOT be automatically installed on the system where the setup script is being run. They are simply downloaded to the setup directory if they’re not locally available already. If you want them to be installed, as well as being available when the setup script is run, you should add them to install_requires and setup_requires..."

unfortunately, I'm not sure this will work because of the separation or responsibilities between pip and setuptools.
