### PR TITLE
Fix #15 Python 3 Support

### DIFF
--- a/django_faker/populator.py
+++ b/django_faker/populator.py
@@ -173,7 +173,7 @@ class Populator(object):
         klass = self.entities.keys()
         if not klass:
             raise AttributeError('No class found from entities. Did you add entities to the Populator ?')
-        klass = klass[0]
+        klass = list(klass)[0]
 
         return klass.objects._db
 


### PR DESCRIPTION
In py3.x dict.keys() returns a set like view object, not list(so, indexing is not possible).