### PR TITLE
Correct fake-factory package links to point to Faker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Django-faker
 ============
 
-*Django-faker* uses `fake-factory`_ package to generate test data for Django models and templates.
+*Django-faker* uses the `Faker`_ package to generate test data for Django models and templates.
 
 |pypi| |unix_build| |windows_build| |coverage| |downloads| |license|
 
@@ -153,7 +153,7 @@ Changelog
 `0.3dev <http://github.com/joke2k/django-faker/compare/v0.2...master>`__
 ------------------------------------------------------------------------
 
-- Upgrade fake-factory version
+- fake-factory package was renamed to Faker, requires a minimum version of 0.7.3
 
 `0.2 - 23-January-2013 <http://github.com/joke2k/django-faker/compare/v0.1...v0.2>`__
 -------------------------------------------------------------------------------------
@@ -168,7 +168,7 @@ Changelog
 - Add django template tag and filter
 
 
-.. _fake-factory: https://www.github.com/joke2k/faker/
+.. _Faker: https://www.github.com/joke2k/faker/
 
 .. |pypi| image:: https://img.shields.io/pypi/v/django-faker.svg?style=flat-square&label=version
     :target: https://pypi.python.org/pypi/django-faker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 django
-fake-factory==0.5.3
+Faker>=0.7.3

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ setup(
     ],
     keywords='faker fixtures data test django',
     long_description=read_file('README.rst'),
-    install_requires=['django','fake-factory==0.2'],
-    tests_require=['django','fake-factory==0.2'],
+    install_requires=['django','Faker>=0.7.3'],
+    tests_require=['django','Faker>=0.7.3'],
     test_suite="runtests.runtests",
     zip_safe=False,
 )


### PR DESCRIPTION
fake-factory moved to Faker on Pypi, with a minimum version of 0.7.3:
https://github.com/joke2k/faker/issues/331
